### PR TITLE
allow for disabling a key

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
 keyboard:
   Capslock: Backspace
   Backspace: Delete
+  ControlRight: Disable

--- a/remap.py
+++ b/remap.py
@@ -68,7 +68,12 @@ def create_property(
     for keyinput, mappings in config.items():
         for src_key_name, dst_key_name in mappings.items():
             src_key_id = key_id(keytables[keyinput][src_key_name])
-            dst_key_id = key_id(keytables[keyinput][dst_key_name])
+
+            if dst_key_name == 'Disable':
+                dst_key_id = 0xFFFFFFFF
+            else:
+                dst_key_id = key_id(keytables[keyinput][dst_key_name])
+
             res.append(remap(src_key_id, dst_key_id))
 
     res = {"UserKeyMapping": res}


### PR DESCRIPTION
## Problem

There are a few keys that I'd like to get out of the habit of using. I had remapped those keys to 'Home' or 'End' or some other unused keys, but this resulted in undesirable behavior when writing software (cursor jumps). I really just wanted to disable a key whose functionality I'd remapped elsewhere.

## Solution

I've added support for unmapping a key by interpreting the string "Disabled" into a value outside of the acceptable range of HID keyboard values.